### PR TITLE
Fix warnings on PHP 8.1

### DIFF
--- a/src/AbstractJsonEncoder.php
+++ b/src/AbstractJsonEncoder.php
@@ -123,6 +123,7 @@ abstract class AbstractJsonEncoder implements \Iterator
      * Returns the current number of step in the encoder.
      * @return int|null The current step number as integer or null if the current state is not valid
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         $this->initialize();
@@ -134,6 +135,7 @@ abstract class AbstractJsonEncoder implements \Iterator
      * Tells if the encoder has a valid current state.
      * @return bool True if the iterator has a valid state, false if not
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         $this->initialize();
@@ -145,11 +147,13 @@ abstract class AbstractJsonEncoder implements \Iterator
      * Returns the current value or state from the encoder.
      * @return mixed The current value or state from the encoder
      */
+    #[\ReturnTypeWillChange]
     abstract public function current();
 
     /**
      * Returns the JSON encoding to the beginning.
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         if ($this->step === 0) {
@@ -172,6 +176,7 @@ abstract class AbstractJsonEncoder implements \Iterator
     /**
      * Iterates the next token or tokens to the output stream.
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->initialize();


### PR DESCRIPTION
With, PHP 8.1 lack of a return type hint for a method of a child class, whose parent has return type hint is considered mismatch.

https://php.watch/versions/8.1/internal-method-return-types#no-return-type

Since standard classes and interfaces started adding typehings, errors like the following are produced:

    PHP Deprecated: Return type of Violet\StreamingJsonEncoder\AbstractJsonEncoder::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

`void` type is only available since PHP 7.1 and `mixed` type requires PHP 8.0:

https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.void
https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.mixed

To preserve compatibility with PHP < 8.0, we need to add the attribute.
